### PR TITLE
Add new setting to allow for interacting with the map when not moused over it

### DIFF
--- a/comfy_map.lua
+++ b/comfy_map.lua
@@ -37,6 +37,7 @@ local default_colors = stringify{
 
 local defaults = {
   centered = false,
+  alwaysAllowMapInteraction = false,
   centered_zoom = 0.5,
   centered_offset = 0,
   rotation = true,
@@ -183,7 +184,7 @@ function script.windowMain(dt)
   ui.pushClipRect(0, ui.windowSize()) --background
   ui.invisibleButton()
 
-  if windowHovered then --zoom&drag&centering&reset
+  if windowHovered or settings.alwaysAllowMapInteraction then --zoom&drag&centering&reset
     if ac.getUI().mouseWheel ~= 0 then
       if (ac.getUI().mouseWheel < 0 and (size>ui.windowSize()*0.97)) or ac.getUI().mouseWheel > 0 then
         local old = size
@@ -207,7 +208,6 @@ function script.windowMain(dt)
 
   if settings.centered then --center on car and rotate
     offsets:set(focusedCar.position.x, focusedCar.position.z):add(config_offset):scale(config_scale):add(-ui.windowSize()*centered_offset) --autocenter
-
     if settings.rotation then
       rotationangle = 180 - math.deg(math.atan2(focusedCar.look.x, focusedCar.look.z))
       rotation = mat4x4.rotation(math.rad(rotationangle), vec.y)
@@ -408,6 +408,8 @@ function script.windowMainSettings(dt)
         ui.unindent()
         if ui.itemHovered() then ui.setTooltip('middle click map to toggle rotation') end
       end
+      if ui.checkbox("Control map at any time", settings.alwaysAllowMapInteraction) then settings.alwaysAllowMapInteraction = not settings.alwaysAllowMapInteraction end
+      if ui.itemHovered() then ui.setTooltip('Allow for middle click and scrollwheel to control the map even when not hovering the mouse over it. Good for using with wheel bindings') end
       if ui.checkbox("teleports", settings.teleporting) then settings.teleporting = not settings.teleporting end
       if settings.teleporting then
         ui.indent()

--- a/comfy_map.lua
+++ b/comfy_map.lua
@@ -186,6 +186,8 @@ function script.windowMain(dt)
   ui.pushClipRect(0, ui.windowSize()) --background
   ui.invisibleButton()
 
+  focusedCar = ac.getCar(ac.getSim().focusedCar)
+
   if windowHovered or (settings.always_allow_beeg_interaction and settings.always_allow_map_interaction) then --zoom&drag&centering&reset
     if ac.getUI().mouseWheel ~= 0 then
       if (ac.getUI().mouseWheel < 0 and (size>ui.windowSize()*0.97)) or ac.getUI().mouseWheel > 0 then
@@ -193,7 +195,11 @@ function script.windowMain(dt)
         map_scale = map_scale * (1 + math.sign(ac.getUI().mouseWheel) * 0.15)
         size = ui.imageSize(current_map) * map_scale
         config_scale = map_scale / config.SCALE_FACTOR
-        offsets = offsets + (size - old) * (offsets + ui.mouseLocalPos()) / old -- DON'T touch, powered by dark magic
+        focus = ui.mouseLocalPos()
+        if not windowHovered then
+          focus:set(focusedCar.position.x, focusedCar.position.z):add(config_offset):scale(config_scale):add(-offsets)
+        end
+        offsets = offsets + (size - old) * (offsets + focus) / old -- DON'T touch, powered by dark magic
       else
         resetScale()
       end
@@ -206,7 +212,6 @@ function script.windowMain(dt)
     end
   end
 
-  focusedCar = ac.getCar(ac.getSim().focusedCar)
 
   if settings.centered then --center on car and rotate
     offsets:set(focusedCar.position.x, focusedCar.position.z):add(config_offset):scale(config_scale):add(-ui.windowSize()*centered_offset) --autocenter
@@ -369,7 +374,7 @@ function script.windowMain(dt)
 
 
   windowHovered = ui.windowHovered(105) or draggingMap
-  if not settings.centered then --window movable while centered
+  if not settings.centered then --window not movable while centered
     ui.setCursor() ui.invisibleButton('draggingbutton', ui.windowSize())
     draggingMap = ((ui.mouseDown() and ui.itemHovered()) or draggingMap) and ui.mouseDown()
     if draggingMap then offsets = offsets - ui.mouseDelta() end

--- a/comfy_map.lua
+++ b/comfy_map.lua
@@ -37,7 +37,9 @@ local default_colors = stringify{
 
 local defaults = {
   centered = false,
-  alwaysAllowMapInteraction = false,
+  always_allow_map_interaction = false,
+  always_allow_beeg_interaction = false,
+  always_allow_smol_interaction = false,
   centered_zoom = 0.5,
   centered_offset = 0,
   rotation = true,
@@ -184,7 +186,7 @@ function script.windowMain(dt)
   ui.pushClipRect(0, ui.windowSize()) --background
   ui.invisibleButton()
 
-  if windowHovered or settings.alwaysAllowMapInteraction then --zoom&drag&centering&reset
+  if windowHovered or (settings.always_allow_beeg_interaction and settings.always_allow_map_interaction) then --zoom&drag&centering&reset
     if ac.getUI().mouseWheel ~= 0 then
       if (ac.getUI().mouseWheel < 0 and (size>ui.windowSize()*0.97)) or ac.getUI().mouseWheel > 0 then
         local old = size
@@ -408,8 +410,14 @@ function script.windowMainSettings(dt)
         ui.unindent()
         if ui.itemHovered() then ui.setTooltip('middle click map to toggle rotation') end
       end
-      if ui.checkbox("Control map at any time", settings.alwaysAllowMapInteraction) then settings.alwaysAllowMapInteraction = not settings.alwaysAllowMapInteraction end
-      if ui.itemHovered() then ui.setTooltip('Allow for middle click and scrollwheel to control the map even when not hovering the mouse over it. Good for using with wheel bindings') end
+      if ui.checkbox("control maps at any time", settings.always_allow_map_interaction) then settings.always_allow_map_interaction = not settings.always_allow_map_interaction end
+      if ui.itemHovered() then ui.setTooltip('allow for middle click and scrollwheel to control the map even when not hovering the mouse over it. good for using with wheel bindings') end
+      if settings.always_allow_map_interaction then
+        ui.indent()
+        if ui.checkbox("control big map at any time", settings.always_allow_beeg_interaction) then settings.always_allow_beeg_interaction = not settings.always_allow_beeg_interaction end
+        if ui.checkbox("control smol map at any time", settings.always_allow_smol_interaction) then settings.always_allow_smol_interaction = not settings.always_allow_smol_interaction end
+        ui.unindent()
+      end
       if ui.checkbox("teleports", settings.teleporting) then settings.teleporting = not settings.teleporting end
       if settings.teleporting then
         ui.indent()
@@ -589,7 +597,7 @@ function windowSmol(dt)
   if first then return end
 
   ui.invisibleButton()
-  if ui.windowHovered() and ui.mouseWheel() then smol_scale = smol_scale * (1 + 0.1 * ui.mouseWheel()) end
+  if (ui.windowHovered() or (settings.always_allow_smol_interaction and settings.always_allow_map_interaction)) and ui.mouseWheel() then smol_scale = smol_scale * (1 + 0.1 * ui.mouseWheel()) end
   focusedCar = ac.getCar(ac.getSim().focusedCar)
   offsets1:set(focusedCar.position.x, focusedCar.position.z):add(config_offset):scale(smol_scale / config.SCALE_FACTOR):add(-ui.windowSize()*centered_offset) --autocenter
 


### PR DESCRIPTION
This change is good for controlling the map with mappings on your wheel. Since you don't need the mouse over the map when this setting is enabled. You can just bind middle mouse click and scroll up/down to buttons on your wheel or a button box and control the map that way.

This setting is false by default to maintain the current behavior. 

Booted into AC and tested it out. 
- Setting enabled: Scrolling/middle click controlled the map at all times.
- Setting disabled: Scrolling/middle click controlled the map only when the mouse was over it. 